### PR TITLE
Deploy action gke

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -1,0 +1,57 @@
+name: "Build Custom TFServing Docker Image"
+description: "This action builds a custom TFServing Docker image from the latest released model"
+inputs:
+  GCP_PROJECT_ID:
+    reuiqred: true
+    description: "The GCP Project ID"
+  MODEL_RELEASE_REPO:
+    required: true
+    description: "The Github repo where the released models are"
+  MODEL_RELEASE_FILE:
+    required: true
+    description: "The released SavedModel filename compressed in tar.gz"
+  MODEL_NAME:
+    required: true
+    description: "The model name to be exposed by TFServing"
+  BASE_IMAGE_TAG:
+    required: true
+    description: "The base TFServing image to build a custom one upon"
+outputs:
+  NEW_IMAGE_TAG:
+    description: "Assigned image tag"
+    value: ${{ steps.push-to-registry.outputs.NEW_IMAGE_TAG }}    
+runs:
+  using: "composite"
+  steps:
+      - name: Download the latest model release
+        uses: robinraju/release-downloader@v1.3
+        with:
+          repository: ${{ inputs.MODEL_RELEASE_REPO }}
+          latest: true
+          fileName: ${{ inputs.MODEL_RELEASE_FILE }}
+          
+      - name: Extract the SavedModel
+        run: |
+          mkdir ${{ inputs.MODEL_NAME }}
+          tar -xvf ${{ inputs.MODEL_RELEASE_FILE }} --strip-components=1 --directory ${{ inputs.MODEL_NAME }}
+        shell: bash          
+    
+      - name: Run the CPU optimized TFServing container
+        run: |
+          docker run -d --name serving_base ${{ inputs.BASE_IMAGE_TAG }}
+        shell: bash          
+          
+      - name: Copy the custom model to the running TFServing container
+        run: |
+          docker cp ${{ inputs.MODEL_NAME }} serving_base:/models/${{ inputs.MODEL_NAME }}
+        shell: bash          
+          
+      - id: push-to-registry
+        name: Commit and push the changed running TFServing container(image)
+        run: |
+          export NEW_IMAGE_NAME=tfserving-${{ inputs.MODEL_NAME }}:latest
+          export NEW_IMAGE_TAG=gcr.io/${{ inputs.GCP_PROJECT_ID }}/$NEW_IMAGE_NAME
+          echo "::set-output name=NEW_IMAGE_TAG::$(echo $NEW_IMAGE_TAG)"
+          docker commit --change "ENV MODEL_NAME ${{ inputs.MODEL_NAME }}" serving_base $NEW_IMAGE_TAG
+          docker push $NEW_IMAGE_TAG
+        shell: bash

--- a/.github/actions/provision/action.yaml
+++ b/.github/actions/provision/action.yaml
@@ -1,0 +1,40 @@
+name: "Provision Deployment to the GKE cluster"
+description: "This action provisions custom built TFServing Docker image to the GKE cluster"
+inputs:
+  BASE_IMAGE_TAG:
+    reuiqred: true
+    description: "The default image tag"
+  NEW_IMAGE_TAG:
+    required: true
+    description: "The image tag to be deployed"
+  TARGET_EXPERIMENT:
+    required: true
+    description: "The target experiment name"
+  GKE_DEPLOYMENT_NAME:
+    required: true
+    description: "The deployemtn name to check out"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Kustomize
+      working-directory: .kube/
+      run: |-
+        curl -sfLo kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.1.2/kustomize_v4.1.2_linux_amd64.tar.gz
+        tar -zxvf kustomize.tar.gz
+        chmod u+x ./kustomize
+      shell: bash
+
+    - name: Update image name
+      working-directory: .kube/experiments/${{ inputs.TARGET_EXPERIMENT }}
+      run: |-
+        ../../kustomize edit set image ${{ inputs.BASE_IMAGE_TAG }}=${{ inputs.NEW_IMAGE_TAG }}
+      shell: bash
+
+    - name: Deploy to GKE
+      working-directory: .kube/
+      run: |-
+        ./kustomize build experiments/${{ inputs.TARGET_EXPERIMENT }} | kubectl apply -f -
+        kubectl rollout status deployment/${{ inputs.GKE_DEPLOYMENT_NAME }}
+        kubectl get services -o wide
+        kubectl describe deployment ${{ inputs.GKE_DEPLOYMENT_NAME }}
+      shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,35 @@
+name: "Setup GCP Authentication"
+description: "This action sets up GCP Authentication for GCR and GKE accesses"
+inputs:
+  GCP_CREDENTIALS:
+    required: true
+    description: "The JSON GCP Credentials"
+  GCP_PROJECT_ID:
+    required: true
+    description: "The GCP PROJECT ID"
+  GKE_CLUSTER_NAME:
+    required: true
+    description: "The GKE Cluster name to deploy TFServing"
+  GKE_CLUSTER_ZONE:
+    required: true
+    description: "The GKE Cluster zone to deploy TFServing"
+runs:
+  using: "composite"
+  steps:
+      - name: GCP auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ inputs.GCP_CREDENTIALS }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+
+      - name: Docker auth
+        run: |-
+          gcloud --quiet auth configure-docker
+        shell: bash          
+      
+      - name: GKE auth
+        run: |-
+          gcloud container clusters get-credentials ${{ inputs.GKE_CLUSTER_NAME }} --zone ${{ inputs.GKE_CLUSTER_ZONE }} --project ${{ inputs.GCP_PROJECT_ID }}  
+        shell: bash

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,0 +1,56 @@
+name: Deployment
+
+env:
+  GCP_PROJECT_ID: "gcp-ml-172005"
+  GKE_CLUSTER_NAME: "tfs-cluster"
+  GKE_ZONE: "us-central1-a"
+  GKE_DEPLOYMENT_NAME: "tfs-server"
+  
+  BASE_IMAGE_TAG: "gcr.io/gcp-ml-172005/tfs-resnet-cpu-opt"
+  MODEL_NAME: "resnet"
+  
+  MODEL_RELEASE_REPO: "deep-diver/ml-deployment-k8s-tfserving"
+  MODEL_RELEASE_FILE: "saved_model.tar.gz"
+  TARGET_EXPERIMENT: "8vCPU+16GB+inter_op4"
+  
+on:
+  release:
+    types: [published]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git
+        uses: actions/checkout@v2
+        
+      - id: setup
+        name: environmental setup
+        uses: ./.github/actions/setup
+        with:
+          GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+          GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
+          GKE_CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_ZONE: ${{ env.GKE_ZONE }}
+         
+      - id: build
+        name: build and push custom TFServing image      
+        uses: ./.github/actions/build
+        with:
+          GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
+          MODEL_RELEASE_REPO: ${{ env.MODEL_RELEASE_REPO }}
+          MODEL_RELEASE_FILE: ${{ env.MODEL_RELEASE_FILE }}
+          MODEL_NAME: ${{ env.MODEL_NAME }}
+          BASE_IMAGE_TAG: ${{ env.BASE_IMAGE_TAG }}
+        
+      - id: provision
+        name: deploy the image to GKE cluster      
+        uses: ./.github/actions/provision
+        with:
+          BASE_IMAGE_TAG: ${{ env.BASE_IMAGE_TAG }}
+          NEW_IMAGE_TAG: ${{ steps.build.outputs.NEW_IMAGE_TAG }}
+          TARGET_EXPERIMENT: ${{ env.TARGET_EXPERIMENT }}
+          GKE_DEPLOYMENT_NAME: ${{ env.GKE_DEPLOYMENT_NAME }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -7,7 +7,7 @@ env:
   GKE_DEPLOYMENT_NAME: "tfs-server"
   
   BASE_IMAGE_TAG: "gcr.io/gcp-ml-172005/tfs-resnet-cpu-opt"
-  MODEL_NAME: "resnet"
+  MODEL_NAME: "tf-vit"
   
   MODEL_RELEASE_REPO: "deep-diver/deploy-hf-tf-vision-models"
   MODEL_RELEASE_FILE: "saved_model.tar.gz"

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -9,7 +9,7 @@ env:
   BASE_IMAGE_TAG: "gcr.io/gcp-ml-172005/tfs-resnet-cpu-opt"
   MODEL_NAME: "tf-vit"
   
-  MODEL_RELEASE_REPO: "deep-diver/deploy-hf-tf-vision-models"
+  MODEL_RELEASE_REPO: "sayakpaul/deploy-hf-tf-vision-models"
   MODEL_RELEASE_FILE: "saved_model.tar.gz"
   TARGET_EXPERIMENT: "8vCPU+16GB+inter_op4"
   

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -9,7 +9,7 @@ env:
   BASE_IMAGE_TAG: "gcr.io/gcp-ml-172005/tfs-resnet-cpu-opt"
   MODEL_NAME: "resnet"
   
-  MODEL_RELEASE_REPO: "deep-diver/ml-deployment-k8s-tfserving"
+  MODEL_RELEASE_REPO: "deep-diver/deploy-hf-tf-vision-models"
   MODEL_RELEASE_FILE: "saved_model.tar.gz"
   TARGET_EXPERIMENT: "8vCPU+16GB+inter_op4"
   

--- a/.kube/base/deployment.yaml
+++ b/.kube/base/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tfs-server
+  name: tfs-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tfs-server
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: tfs-server
+    spec:
+      containers:
+      - image: gcr.io/gcp-ml-172005/tfs-resnet-cpu-opt:latest
+        name: tfs-k8s
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8500
+          name: grpc
+        - containerPort: 8501
+          name: restapi
+        resources: {}

--- a/.kube/base/kustomization.yaml
+++ b/.kube/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: tfs-server
+
+resources:
+- deployment.yaml
+- service.yaml

--- a/.kube/base/service.yaml
+++ b/.kube/base/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: tfs-server
+  name: tfs-server
+spec:
+  ports:
+  - port: 8500
+    protocol: TCP
+    targetPort: 8500
+    name: tf-serving-grpc
+  - port: 8501
+    protocol: TCP
+    targetPort: 8501
+    name: tf-serving-restapi
+  selector:
+    app: tfs-server
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/.kube/experiments/8vCPU+16GB+inter_op4/deployment_replica_count.yaml
+++ b/.kube/experiments/8vCPU+16GB+inter_op4/deployment_replica_count.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+ name: tfs-server
+
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: tfs-server
+    spec:
+      containers:
+      - image: gcr.io/gcp-ml-172005/tfs-resnet-cpu-opt:latest
+        name: tfs-k8s
+        imagePullPolicy: Always
+        args: ["--tensorflow_inter_op_parallelism=4", "--tensorflow_intra_op_parallelism=8"]
+        ports:
+        - containerPort: 8500
+          name: grpc
+        - containerPort: 8501
+          name: restapi
+        resources: {}

--- a/.kube/experiments/8vCPU+16GB+inter_op4/kustomization.yaml
+++ b/.kube/experiments/8vCPU+16GB+inter_op4/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+patches:
+- deployment_replica_count.yaml


### PR DESCRIPTION
Things to notice
- verified working on GKE cluster
- kept the same structure as our previous [project](https://github.com/deep-diver/ml-deployment-k8s-tfserving) under `.kube` directory
- chose the 8vCPU, 8GB RAM, 2 Nodes strategy
- k8s cluster name should be `tfs-cluster`, but it can be configured as in GitHub Action's environment variable
- after merging, `saved_model.tar.gz` should be released
- after merging, `GCP_CREDENTIALS` should be defined as GitHub Action Secret

You can see the full GitHub Action logs [here](https://github.com/deep-diver/deploy-hf-tf-vision-models/runs/7390339304?check_suite_focus=true)