### PR TITLE
n2 experiments.

### DIFF
--- a/hf_vision_model_tfserving_gke/build_tfserving.sh
+++ b/hf_vision_model_tfserving_gke/build_tfserving.sh
@@ -3,7 +3,7 @@
 export ROOT_DIR=/tmp
 
 export GCP_PROJECT_ID=fast-ai-exploration
-export BASE_IMAGE_TAG=gcr.io/gcp-ml-172005/tfserving:c2-avx512-vnni-base
+export BASE_IMAGE_TAG=gcr.io/fast-ai-exploration/tfserving-n2
 
 ### Repository where to download SavedModel from
 export MODEL_RELEASE_REPO=sayakpaul/deploy-hf-tf-vision-models

--- a/hf_vision_model_tfserving_gke/provision_gke_cluster.sh
+++ b/hf_vision_model_tfserving_gke/provision_gke_cluster.sh
@@ -6,7 +6,7 @@ export NUM_NODES=2
 
 # export NUM_CORES=8
 # export MEM_CAPACITY=16384
-export MACHINE_TYPE=c2-standard-8
+export MACHINE_TYPE=n2-standard-8
 
 source ~/.bashrc
 export USE_GKE_GCLOUD_AUTH_PLUGIN=True


### PR DESCRIPTION
[n2-8vCPU+32GB+inter_op4.tar.gz](https://github.com/sayakpaul/deploy-hf-tf-vision-models/files/9222742/n2-8vCPU%2B32GB%2Binter_op4.tar.gz)


Seems like the requests are failing probably because of the tradeoff between model size and compute.
