### PR TITLE
n1-standard-8 experiments

### DIFF
--- a/hf_vision_model_tfserving_gke/build_tfserving.sh
+++ b/hf_vision_model_tfserving_gke/build_tfserving.sh
@@ -3,7 +3,7 @@
 export ROOT_DIR=/tmp
 
 export GCP_PROJECT_ID=fast-ai-exploration
-export BASE_IMAGE_TAG=gcr.io/fast-ai-exploration/tfserving
+export BASE_IMAGE_TAG=gcr.io/$GCP_PROJECT_ID/tfserving
 
 ### Repository where to download SavedModel from
 export MODEL_RELEASE_REPO=sayakpaul/deploy-hf-tf-vision-models

--- a/hf_vision_model_tfserving_gke/build_tfserving.sh
+++ b/hf_vision_model_tfserving_gke/build_tfserving.sh
@@ -3,7 +3,7 @@
 export ROOT_DIR=/tmp
 
 export GCP_PROJECT_ID=fast-ai-exploration
-export BASE_IMAGE_TAG=gcr.io/$GCP_PROJECT_ID/n1-serving
+export BASE_IMAGE_TAG=gcr.io/gcp-ml-172005/tfs-resnet-cpu-opt
 
 ### Repository where to download SavedModel from
 export MODEL_RELEASE_REPO=sayakpaul/deploy-hf-tf-vision-models

--- a/hf_vision_model_tfserving_gke/build_tfserving.sh
+++ b/hf_vision_model_tfserving_gke/build_tfserving.sh
@@ -3,7 +3,7 @@
 export ROOT_DIR=/tmp
 
 export GCP_PROJECT_ID=fast-ai-exploration
-export BASE_IMAGE_TAG=gcr.io/fast-ai-exploration/tfserving-n2
+export BASE_IMAGE_TAG=gcr.io/fast-ai-exploration/tfserving
 
 ### Repository where to download SavedModel from
 export MODEL_RELEASE_REPO=sayakpaul/deploy-hf-tf-vision-models

--- a/hf_vision_model_tfserving_gke/build_tfserving.sh
+++ b/hf_vision_model_tfserving_gke/build_tfserving.sh
@@ -3,7 +3,7 @@
 export ROOT_DIR=/tmp
 
 export GCP_PROJECT_ID=fast-ai-exploration
-export BASE_IMAGE_TAG=gcr.io/$GCP_PROJECT_ID/tfserving
+export BASE_IMAGE_TAG=gcr.io/$GCP_PROJECT_ID/n1-serving
 
 ### Repository where to download SavedModel from
 export MODEL_RELEASE_REPO=sayakpaul/deploy-hf-tf-vision-models

--- a/hf_vision_model_tfserving_gke/provision_gke_cluster.sh
+++ b/hf_vision_model_tfserving_gke/provision_gke_cluster.sh
@@ -6,7 +6,7 @@ export NUM_NODES=2
 
 # export NUM_CORES=8
 # export MEM_CAPACITY=16384
-export MACHINE_TYPE=n2-standard-8
+export MACHINE_TYPE=n1-standard-8
 
 source ~/.bashrc
 export USE_GKE_GCLOUD_AUTH_PLUGIN=True

--- a/locust/README.md
+++ b/locust/README.md
@@ -4,7 +4,7 @@ This directory contains a Locust script for load testing.
 
 ```
 │   locustfile.py    # REST locust client
-│   load_test.conf   # load test configs
+│   configs.conf   # load test configs
 │   cat_224x224.jpeg # resized test image
 ```
 
@@ -16,16 +16,16 @@ This directory contains a Locust script for load testing.
 pip install locust
 ```
 
-2. Replace placeholderes. In `load_test.conf` and `locustfile.py`, there are three placeholders of `<<ENDPOINT-IP-ADDRESS>>`. You have to replace those with the actual endpoint that your TF Serving is deployed on. Also you need to replace `<<WHERE-TO-STORE-RESPORT>>` placeholders in `load_test.conf` with where you want to save the final report.
+2. Replace placeholderes. In `configs.conf` and `locustfile.py`, there are three placeholders of `<<ENDPOINT-IP-ADDRESS>>`. You have to replace those with the actual endpoint that your TF Serving is deployed on. Also you need to replace `<<WHERE-TO-STORE-RESPORT>>` placeholders in `configs.conf` with where you want to save the final report.
 
 
-3. `locust` the `load_test.conf`. Every bits of configurations are defined in `load_test.conf`, so you only need to specify it in `--config` option.
+3. `locust` the `configs.conf`. Every bits of configurations are defined in `configs.conf`, so you only need to specify it in `--config` option.
 
 ```bash
-$ locust --config=load_test.conf
+$ locust --config=configs.conf
 ```
 
-### Inside `load_test.conf`
+### Inside `configs.conf`
 
 ```
 locustfile = locustfile.py

--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -12,7 +12,7 @@ class ImgClssificationUser(HttpUser):
 
     with open(image_path, "rb") as f:
         bytes_inputs = f.read()
-    b64str = base64.urlsafe_b64encode(bytes_inputs.numpy()).decode("utf-8")
+    b64str = base64.urlsafe_b64encode(bytes_inputs).decode("utf-8")
     data = json.dumps(
         {"signature_name": "serving_default", "instances": [b64str]}
     )

--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -1,8 +1,6 @@
 import base64
 import json
 
-import tensorflow as tf
-
 from locust import HttpUser, constant, task
 
 
@@ -12,7 +10,8 @@ class ImgClssificationUser(HttpUser):
     image_path = "./cat.jpg"
     headers = {"content-type": "application/json"}
 
-    bytes_inputs = tf.io.read_file(image_path)
+    with open(image_path, "rb") as f:
+        bytes_inputs = f.read()
     b64str = base64.urlsafe_b64encode(bytes_inputs.numpy()).decode("utf-8")
     data = json.dumps(
         {"signature_name": "serving_default", "instances": [b64str]}


### PR DESCRIPTION
Locust load tests were run from c2-standard-4 machine as before. 
Below are the results: 

[n1-8vCPU+32GB+inter_op4.tar.gz](https://github.com/sayakpaul/deploy-hf-tf-vision-models/files/9231596/n1-8vCPU%2B32GB%2Binter_op4.tar.gz)

Closes #14 

